### PR TITLE
Check for db engine by substring to support custom postgres engines

### DIFF
--- a/relativedeltafield/__init__.py
+++ b/relativedeltafield/__init__.py
@@ -89,7 +89,7 @@ class RelativeDeltaField(models.Field):
 
 
 	def db_type(self, connection):
-		if connection.settings_dict['ENGINE'] in ('django.db.backends.postgresql_psycopg2', 'django.db.backends.postgresql', 'django.contrib.gis.db.backends.postgis'):
+		if any(engine in connection.settings_dict['ENGINE'] for engine in ['postgresql', 'postgis']):
 			return 'interval'
 		else:
 			raise ValueError(_('RelativeDeltaField only supports PostgreSQL for storage'))


### PR DESCRIPTION
I am using django-tenant-schema app which uses a custom postgresql based db engine, therefore, the db engine check fails. I have slightly modified the check to look for postgresql or postgis substrings  in the ENGINE setting.