### PR TITLE
Add support for Django 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ venv
 /.eggs/
 *.pyc
 .tox/
+.vscode/
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     env: DJANGO_VERSION=2.0.13
   - python: 3.7
     env: DJANGO_VERSION=2.0.13
+  - python: 3.8
+    env: DJANGO_VERSION=2.0.13
 
   - python: 3.5
     env: DJANGO_VERSION=2.1.10
@@ -13,6 +15,8 @@ matrix:
     env: DJANGO_VERSION=2.1.10
   - python: 3.7
     env: DJANGO_VERSION=2.1.10
+  - python: 3.8
+    env: DJANGO_VERSION=2.1.10
 
   - python: 3.5
     env: DJANGO_VERSION=2.2.3
@@ -20,6 +24,15 @@ matrix:
     env: DJANGO_VERSION=2.2.3
   - python: 3.7
     env: DJANGO_VERSION=2.2.3
+  - python: 3.8
+    env: DJANGO_VERSION=2.2.3
+
+  - python: 3.6
+    env: DJANGO_VERSION=3.0.0
+  - python: 3.7
+    env: DJANGO_VERSION=3.0.0
+  - python: 3.8
+    env: DJANGO_VERSION=3.0.0
 
 ccache:
   pip: true

--- a/relativedeltafield/__init__.py
+++ b/relativedeltafield/__init__.py
@@ -137,15 +137,9 @@ class RelativeDeltaField(models.Field):
 		fmt = 'to_char(%s, \'PYYYY"Y"MM"M"DD"DT"HH24"H"MI"M"SS.US"S"\')' % sql
 		return fmt, params
 
-
-	def get_db_converters(self, connection):
-		return [self.convert_relativedeltafield_value]
-
-
-	def convert_relativedeltafield_value(self, value, expression, connection, context):
+	def from_db_value(self, value, expression, connection, context=None):
 		if value is not None:
 			return parse_relativedelta(value)
-
 
 	def value_to_string(self, obj):
 		val = self.value_from_object(obj)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
 		'Framework :: Django :: 2.0',
 		'Framework :: Django :: 2.1',
 		'Framework :: Django :: 2.2',
+		'Framework :: Django :: 3.0',
 		'Intended Audience :: Developers',
 		'License :: OSI Approved :: MIT License',
 		'Operating System :: OS Independent',
@@ -37,12 +38,15 @@ setup(
 		'Programming Language :: Python :: 3',
 		'Programming Language :: Python :: 3.4',
 		'Programming Language :: Python :: 3.5',
+		'Programming Language :: Python :: 3.6',
+		'Programming Language :: Python :: 3.7',
+		'Programming Language :: Python :: 3.8',
 		'Topic :: Database',
 		'Topic :: Internet :: WWW/HTTP',
 		'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
 	],
 	install_requires=[
-		'Django >= 1.10, < 3.0',
+		'Django >= 1.10, < 4.0',
 		'python-dateutil >= 2.6.0',
                 # Disabled (for now?) due to https://github.com/CodeYellowBV/django-relativedelta/issues/6
                 # We never import it directly from the code, so that is okay


### PR DESCRIPTION
It didn't seem like much of a change

- Looks like django internally looks for `from_db_value` in the default implementation of `get_db_converters` and since the use case is simple I default to that
- It seems like the `context` param was deprecated in Django 2.2 and completely removed in 3.0 hence I assign a value of `None` (it wasn't even used for this field)
- All tests pass in both 2.2 and 3.0 versions
- I tested with python 3.7.0 & 3.8.0, if you have other tests suggestions let me know
- A colleague suggested we add a utility like [tox](https://github.com/tox-dev/tox) to automate matrix testing across different python/django versions