### PR TITLE
Using vendor attribute of connection to determine db engine

### DIFF
--- a/relativedeltafield/__init__.py
+++ b/relativedeltafield/__init__.py
@@ -89,7 +89,7 @@ class RelativeDeltaField(models.Field):
 
 
 	def db_type(self, connection):
-		if any(engine in connection.settings_dict['ENGINE'] for engine in ['postgresql', 'postgis']):
+		if connection.vendor == 'postgresql':
 			return 'interval'
 		else:
 			raise ValueError(_('RelativeDeltaField only supports PostgreSQL for storage'))


### PR DESCRIPTION
This patch ensures that every custom postgresql db engine will work instead of relying on the name of the custom driver engine.