### PR TITLE
Remove context parameter to support django 3

### DIFF
--- a/relativedeltafield/__init__.py
+++ b/relativedeltafield/__init__.py
@@ -1,5 +1,6 @@
 import re
 
+import django
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -137,9 +138,14 @@ class RelativeDeltaField(models.Field):
 		fmt = 'to_char(%s, \'PYYYY"Y"MM"M"DD"DT"HH24"H"MI"M"SS.US"S"\')' % sql
 		return fmt, params
 
-	def from_db_value(self, value, expression, connection, context=None):
-		if value is not None:
-			return parse_relativedelta(value)
+	if django.VERSION < (2,):
+		def from_db_value(self, value, expression, connection, context=None):
+			if value is not None:
+				return parse_relativedelta(value)
+	else:
+		def from_db_value(self, value, expression, connection):
+			if value is not None:
+				return parse_relativedelta(value)
 
 	def value_to_string(self, obj):
 		val = self.value_from_object(obj)


### PR DESCRIPTION
Since Django 2 there is a deprecation warning if using the signature with the context parameter. In Django 3 this will stop working. See https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value