### PR TITLE
~fix invalid dependency constraint warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ test_deps = [
     'pytest-pythonpath>=0.7.3',
     'pytest-echo>=1.7.1',
     'pytest-coverage',
-    'pytest-django >= ^3.7.0',
+    'pytest-django >= 3.7.0',
     'tox >= 3.14.3',
     'tox-pyenv >= 1.1.0',
     'bump2version >= 1.0.0',


### PR DESCRIPTION
Poetry throws a warning message regarding the incorrect dependency constraint for pytest-django -

```
Updating dependencies
Resolving dependencies... (24.7s)PackageInfo: Invalid constraint (pytest-django (>=^3.7.0) ; extra == 'test') found in django-relativedelta-1.1.2 dependencies, skipping
<debug>PackageInfo:</debug> Invalid constraint (pytest-django (>=^3.7.0) ; extra == 'test') found in django-relativedelta-1.1.2 dependencies, skipping
```