### PR TITLE
fix deprecation warning for `ugettext_lazy`

### DIFF
--- a/src/relativedeltafield/fields.py
+++ b/src/relativedeltafield/fields.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from relativedeltafield.utils import (format_relativedelta,
                                       parse_relativedelta,


### PR DESCRIPTION
now that django 4 is released, it's time to release this change.

closes #21 