### PR TITLE
Fix negative fractional of seconds

### DIFF
--- a/src/relativedeltafield/fields.py
+++ b/src/relativedeltafield/fields.py
@@ -99,6 +99,9 @@ class RelativeDeltaField(models.Field):
     def select_format(self, compiler, sql, params):
         if compiler.connection.vendor == 'postgresql':
             fmt = 'to_char(%s, \'PYYYY"Y"MM"M"DD"DT"HH24"H"MI"M"SS.US"S"\')' % sql
+            # Use replace to avoid creation of intervals where the
+            # fractional (microseconds) part of seconds is negative.
+            fmt = 'replace(%s, \'.-\', \'.\')' % fmt
         else:
             fmt = sql
         return fmt, params


### PR DESCRIPTION
This created a non conforming interval such as `P0000Y00M-12DT-13H-02M-39.-215749S`. This would not pass validation and would lead to a crash.